### PR TITLE
Parton shower weights handle new naming scheme

### DIFF
--- a/GeneratorInterface/Core/interface/WeightHelper.h
+++ b/GeneratorInterface/Core/interface/WeightHelper.h
@@ -41,6 +41,8 @@ namespace gen {
     // TODO: Make this only print from one thread a la 
     // https://github.com/kdlong/cmssw/blob/master/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc#L1069
     bool debug_ = true;
+    const unsigned int FIRST_PSWEIGHT_ENTRY= 2;
+    const unsigned int DEFAULT_PSWEIGHT_LENGTH = 46;
     std::string model_;
     std::vector<ParsedWeight> parsedWeights_;
     std::map<std::string, std::string> currWeightAttributeMap_;

--- a/GeneratorInterface/Core/src/GenWeightHelper.cc
+++ b/GeneratorInterface/Core/src/GenWeightHelper.cc
@@ -42,8 +42,9 @@ namespace gen {
         parsedWeights_.push_back(
             {"", index, weightName, weightName, std::unordered_map<std::string, std::string>(), groupIndex});
         if (isPartonShowerWeightGroup(parsedWeights_.back())) {
-          if (showerGroupIndex < 0)
+          if (showerGroupIndex < 0) {
               showerGroupIndex = ++groupIndex;
+          }
           parsedWeights_.back().wgtGroup_idx = showerGroupIndex;  // all parton showers are grouped together
         }
       }

--- a/GeneratorInterface/Core/src/WeightHelper.cc
+++ b/GeneratorInterface/Core/src/WeightHelper.cc
@@ -279,9 +279,14 @@ namespace gen {
         std::cout << wgt.description() << "\n";
       } else if (wgt.weightType() == gen::WeightType::kPartonShowerWeights) {
         auto& wgtPS = dynamic_cast<gen::PartonShowerWeightGroupInfo&>(wgt);
-        for (auto group : wgtPS.getWeightNames()) {
-          std::cout << group << ": up " << wgtPS.upIndex(group);
-          std::cout << " - down " << wgtPS.downIndex(group) << std::endl;
+        if (wgtPS.containedIds().size() == DEFAULT_PSWEIGHT_LENGTH)
+            wgtPS.setIsWellFormed(true);
+
+        wgtPS.cacheWeightIndicesByLabel();
+        std::vector<std::string> labels = wgtPS.weightLabels();
+        if (labels.size() > FIRST_PSWEIGHT_ENTRY && labels.at(FIRST_PSWEIGHT_ENTRY).find(":") != std::string::npos &&
+                labels.at(FIRST_PSWEIGHT_ENTRY).find("=") != std::string::npos) {
+          wgtPS.setNameIsPythiaSyntax(true);
         }
       }
       if (!wgt.isWellFormed())

--- a/GeneratorInterface/Core/src/WeightHelper.cc
+++ b/GeneratorInterface/Core/src/WeightHelper.cc
@@ -118,6 +118,12 @@ namespace gen {
         scaleGroup.setLhaid(-2);
       }
     }
+    if (!(scaleGroup.centralIndex() >= 0 && scaleGroup.muR05muF05Index() >= 0 && 
+        scaleGroup.muR1muF05Index() >= 0 && scaleGroup.muR2muF05Index() >= 0 && 
+        scaleGroup.muR05muF1Index() >= 0 && scaleGroup.muR05muF2Index() >= 0 &&
+        scaleGroup.muR1muF2Index() >= 0 && scaleGroup.muR2muF2Index() >= 0 &&
+        scaleGroup.muR2muF2Index() >= 0))
+      scaleGroup.setIsWellFormed(true);
   }
 
   int WeightHelper::lhapdfId(const ParsedWeight& weight, gen::PdfWeightGroupInfo& pdfGroup) {

--- a/PhysicsTools/NanoAOD/plugins/LHEWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/LHEWeightsTableProducer.cc
@@ -272,12 +272,10 @@ void LHEWeightsTableProducer::addWeightGroupToTable(std::map<gen::WeightType, st
     gen::WeightType weightType = groupInfo.group->weightType();
     std::string name = weightTypeNames_.at(weightType);
     std::string label = "[" + std::to_string(typeCount[weightType]) + "] " + groupInfo.group->name();
-    auto& weights = allWeights.at(groupInfo.index);
     label.append("[");
     label.append(std::to_string(lheWeightTables[weightType].size()));//to append the start index of this set
     label.append("]; ");
-    lheWeightTables[weightType].insert(lheWeightTables[weightType].end(), weights.begin(), weights.end());
-    weightVecsizes[weightType].emplace_back(weights.size());
+    auto& weights = allWeights.at(groupInfo.index);
     if (weightType == gen::WeightType::kScaleWeights && groupInfo.group->isWellFormed() &&
  	groupInfo.group->nIdsContained() < 10) {
       weights = orderedScaleWeights(weights, dynamic_cast<const gen::ScaleWeightGroupInfo*>(groupInfo.group));
@@ -289,6 +287,8 @@ void LHEWeightsTableProducer::addWeightGroupToTable(std::map<gen::WeightType, st
       weights = getPreferredPSweights(weights, dynamic_cast<const gen::PartonShowerWeightGroupInfo*>(groupInfo.group));
       label.append("PS weights (w_var / w_nominal); [0] is ISR=0.5 FSR=1; [1] is ISR=1 FSR=0.5; [2] is ISR=2 FSR=1; [3] is ISR=1 FSR=2");
     } 
+    lheWeightTables[weightType].insert(lheWeightTables[weightType].end(), weights.begin(), weights.end());
+    weightVecsizes[weightType].emplace_back(weights.size());
     //else
     //  label.append(groupInfo.group->description());
     if(weightlabels[weightType] == "") 
@@ -336,11 +336,11 @@ std::vector<double> LHEWeightsTableProducer::getPreferredPSweights(const std::ve
 								   const gen::PartonShowerWeightGroupInfo* pswV) const {
   std::vector<double> psTosave;
   
-  double baseline = psWeights.at(pswV->weightIndexFromLabel("Baseline"));//at 1
-  psTosave.emplace_back( psWeights.at(pswV->weightIndexFromLabel("isrDefHi"))/baseline ); // at 6
-  psTosave.emplace_back( psWeights.at(pswV->weightIndexFromLabel("fsrDefHi"))/baseline ); // at 7
-  psTosave.emplace_back( psWeights.at(pswV->weightIndexFromLabel("isrDefLo"))/baseline ); // at 8
-  psTosave.emplace_back( psWeights.at(pswV->weightIndexFromLabel("fsrDefLo"))/baseline ); // at 9
+  double baseline = psWeights.at(pswV->weightIndexFromLabel("Baseline"));
+  psTosave.emplace_back(psWeights.at(pswV->variationIndex(true, true, gen::PSVarType::def))/baseline);
+  psTosave.emplace_back(psWeights.at(pswV->variationIndex(false, true, gen::PSVarType::def))/baseline);
+  psTosave.emplace_back(psWeights.at(pswV->variationIndex(true, false, gen::PSVarType::def))/baseline);
+  psTosave.emplace_back(psWeights.at(pswV->variationIndex(false, false, gen::PSVarType::def))/baseline);
   return psTosave;
 }
 

--- a/SimDataFormats/GeneratorProducts/interface/PartonShowerWeightGroupInfo.h
+++ b/SimDataFormats/GeneratorProducts/interface/PartonShowerWeightGroupInfo.h
@@ -6,6 +6,9 @@
 #include "SimDataFormats/GeneratorProducts/interface/WeightGroupInfo.h"
 
 namespace gen {
+  enum class PSVarType { muR, cNS, con, def, red};
+  enum class PSSplittingType { combined, g2gg, x2xg, g2qq };
+
   class PartonShowerWeightGroupInfo : public WeightGroupInfo {
   public:
     PartonShowerWeightGroupInfo() : PartonShowerWeightGroupInfo("") {}
@@ -17,22 +20,13 @@ namespace gen {
     virtual ~PartonShowerWeightGroupInfo() override {}
     void copy(const PartonShowerWeightGroupInfo &other);
     virtual PartonShowerWeightGroupInfo *clone() const override;
-
-    // TODO: replace these general functions with specific ones
-    int upIndex(std::string weightName) { 
-      int index = weightIndexFromLabel(weightName+"Hi");
-      return index >= 0 ? index : weightIndexFromLabel(weightName+"_up"); 
-    }
-    int downIndex(std::string weightName) {
-      int index = weightIndexFromLabel(weightName+"Low");
-      return index >= 0 ? index : weightIndexFromLabel(weightName+"_dn"); 
-    }
-    std::vector<std::string> getWeightNames() const { return weightNames; }
+    void setNameIsPythiaSyntax(bool isPythiaSyntax) { nameIsPythiaSyntax_ = isPythiaSyntax; }
+    bool nameIsPythiaSyntax(bool isPythiaSyntax) const { return nameIsPythiaSyntax_; }
+    int variationIndex(bool isISR, bool isUp, PSVarType variationType, PSSplittingType splittingType) const;
+    int variationIndex(bool isISR, bool isUp, PSVarType variationType) const;
 
   private:
-    std::unordered_map<std::string, std::pair<size_t, size_t>> weightNameToUpDown;
-    std::vector<std::string> weightNames;
-    // Is a variation of the functional form of the dynamic scale
+    bool nameIsPythiaSyntax_ = false;
   };
 }  // namespace gen
 

--- a/SimDataFormats/GeneratorProducts/interface/ScaleWeightGroupInfo.h
+++ b/SimDataFormats/GeneratorProducts/interface/ScaleWeightGroupInfo.h
@@ -22,6 +22,7 @@ namespace gen {
     inline bool isValidValue(float mu) const { return mu == 0.5 || mu == 1.0 || mu == 2.0; }
 
   public:
+    static const unsigned int MIN_SCALE_VARIATIONS = 9;
     ScaleWeightGroupInfo() : ScaleWeightGroupInfo("") {}
     ScaleWeightGroupInfo(std::string header, std::string name)
         : WeightGroupInfo(header, name), muIndices_(9, -1), dynVec_(9) {
@@ -43,15 +44,15 @@ namespace gen {
     // Is a variation of the functional form of the dynamic scale
     bool isFunctionalFormVariation();
     void setIsFunctionalFormVariation(bool functionalVar) { isFunctionalFormVar_ = functionalVar; }
-    size_t centralIndex() const { return muIndices_.at(4); }
-    size_t muR1muF2Index() const { return muIndices_.at(5); }
-    size_t muR1muF05Index() const { return muIndices_.at(3); }
-    size_t muR2muF05Index() const { return muIndices_.at(6); }
-    size_t muR2muF1Index() const { return muIndices_.at(7); }
-    size_t muR2muF2Index() const { return muIndices_.at(8); }
-    size_t muR05muF05Index() const { return muIndices_.at(0); }
-    size_t muR05muF1Index() const { return muIndices_.at(1); }
-    size_t muR05muF2Index() const { return muIndices_.at(2); }
+    int centralIndex() const { return muIndices_.at(4); }
+    int muR1muF2Index() const { return muIndices_.at(5); }
+    int muR1muF05Index() const { return muIndices_.at(3); }
+    int muR2muF05Index() const { return muIndices_.at(6); }
+    int muR2muF1Index() const { return muIndices_.at(7); }
+    int muR2muF2Index() const { return muIndices_.at(8); }
+    int muR05muF05Index() const { return muIndices_.at(0); }
+    int muR05muF1Index() const { return muIndices_.at(1); }
+    int muR05muF2Index() const { return muIndices_.at(2); }
     // dynweight version
     size_t centralIndex(std::string& dynName) const { return getScaleIndex(4, dynName); }
     size_t muR1muF2Index(std::string& dynName) const { return getScaleIndex(5, dynName); }

--- a/SimDataFormats/GeneratorProducts/interface/WeightGroupInfo.h
+++ b/SimDataFormats/GeneratorProducts/interface/WeightGroupInfo.h
@@ -43,9 +43,9 @@ namespace gen {
   public:
     WeightGroupInfo() : WeightGroupInfo("") {}
     WeightGroupInfo(std::string header, std::string name)
-        : isWellFormed_(true), headerEntry_(header), name_(name), firstId_(-1), lastId_(-1) {}
+        : isWellFormed_(false), headerEntry_(header), name_(name), firstId_(-1), lastId_(-1) {}
     WeightGroupInfo(std::string header)
-        : isWellFormed_(true), headerEntry_(header), name_(header), firstId_(-1), lastId_(-1) {}
+        : isWellFormed_(false), headerEntry_(header), name_(header), firstId_(-1), lastId_(-1) {}
     WeightGroupInfo(const WeightGroupInfo& other) { copy(other); }
     WeightGroupInfo& operator=(const WeightGroupInfo& other) {
       copy(other);
@@ -85,6 +85,7 @@ namespace gen {
     void setIsWellFormed(bool wellFormed) { isWellFormed_ = wellFormed; }
     bool isWellFormed() const { return isWellFormed_; }
     int weightIndexFromLabel(std::string weightLabel) const;
+    std::vector<std::string> weightLabels() const;
 
   protected:
     bool isWellFormed_;

--- a/SimDataFormats/GeneratorProducts/src/PartonShowerWeightGroupInfo.cc
+++ b/SimDataFormats/GeneratorProducts/src/PartonShowerWeightGroupInfo.cc
@@ -1,9 +1,76 @@
 #include "SimDataFormats/GeneratorProducts/interface/PartonShowerWeightGroupInfo.h"
+#include <exception>
+#include <iostream>
 
 namespace gen {
-  void PartonShowerWeightGroupInfo::copy(const PartonShowerWeightGroupInfo& other) { WeightGroupInfo::copy(other); }
+  void PartonShowerWeightGroupInfo::copy(const PartonShowerWeightGroupInfo& other) { 
+    WeightGroupInfo::copy(other); 
+    nameIsPythiaSyntax_ = other.nameIsPythiaSyntax_;
+  }
 
   PartonShowerWeightGroupInfo* PartonShowerWeightGroupInfo::clone() const {
     return new PartonShowerWeightGroupInfo(*this);
   }
+
+  int PartonShowerWeightGroupInfo::variationIndex(bool isISR, bool isUp, PSVarType variationType) const {
+    return variationIndex(isISR, isUp, variationType, PSSplittingType::combined);
+  }
+
+  int PartonShowerWeightGroupInfo::variationIndex(bool isISR, bool isUp, PSVarType variationType, 
+          PSSplittingType splittingType) const {
+        std::string label = isISR ? "isr" : "fsr";
+
+        if ((variationType == PSVarType::con || variationType == PSVarType::def || variationType == PSVarType::red) 
+                && splittingType != PSSplittingType::combined)
+            throw std::invalid_argument("VariationType must be muR or CNS if subprocess is specified");
+
+        std::string variation;
+        switch(variationType) {
+            case PSVarType::con:
+                variation = !nameIsPythiaSyntax_ ? "Con" : (isUp ? "murfac=4.0" : "murfac=0.25");
+                break;
+            case PSVarType::def:
+                variation = !nameIsPythiaSyntax_ ? "Def" : (isUp ? "murfac=2.0" : "murfac=0.5");
+                break;
+            case PSVarType::red:
+                variation = !nameIsPythiaSyntax_ ? "Red" : (isUp ? "murfac=1.414" : "murfac=0.707");
+            case PSVarType::muR:
+                variation = !nameIsPythiaSyntax_ ? "muR" : (isUp ? "murfac=2.0" : "murfac=0.5");
+                break;
+            case PSVarType::cNS:
+                variation = !nameIsPythiaSyntax_ ? "cNS" : (isUp ? "cns=2.0" : "murfac=-2.0");
+                break;
+        }
+
+        std::string splitting;
+        switch(splittingType) {
+            case PSSplittingType::g2gg:
+                splitting = !nameIsPythiaSyntax_ ? "G2GG" : "g2gg";
+                break;
+            case PSSplittingType::g2qq:
+                splitting = !nameIsPythiaSyntax_ ? "G2QQ" : "g2qq";
+                break;
+            case PSSplittingType::x2xg:
+                splitting = !nameIsPythiaSyntax_ ? "X2XG" : "x2xg";
+                break;
+            default:
+                break;
+        }
+
+        if (nameIsPythiaSyntax_) {
+            std::string app = splittingType != PSSplittingType::combined ? splitting + ":" + variation : variation;
+            label += ":" + app; 
+        }
+        else {
+            if (splittingType != PSSplittingType::combined) {
+                label += variation + "_" + splitting + "_" + variation + (isUp ? "_up" : "_dn");
+            }
+            else 
+                label += variation + (isUp ? "Hi" : "Lo");
+        }
+
+        return weightIndexFromLabel(label);
+
+    }
+
 }  // namespace gen

--- a/SimDataFormats/GeneratorProducts/src/WeightGroupInfo.cc
+++ b/SimDataFormats/GeneratorProducts/src/WeightGroupInfo.cc
@@ -89,6 +89,14 @@ namespace gen {
         weightLabelsToIndices_[weight.label] = weight.localIndex;
   }
 
+  std::vector<std::string> WeightGroupInfo::weightLabels() const {
+    std::vector<std::string> labels;
+    labels.reserve(idsContained_.size());
+    for (const auto& weight : idsContained_)
+      labels.push_back(weight.label);
+    return labels;
+  }
+
   int WeightGroupInfo::weightIndexFromLabel(std::string weightLabel) const {
       if (!weightLabelsToIndices_.empty()) {
         if (weightLabelsToIndices_.find(weightLabel) != weightLabelsToIndices_.end())


### PR DESCRIPTION
Moved some of the logic to PartonShowerWeightGroup to be able to handle both the old and new Pythia PS weight naming scheme. Should still add a check that all weights are found.